### PR TITLE
Verify JWT signature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/robbiemcmichael/kube-auth-hub
 go 1.13
 
 require (
+	github.com/google/go-cmp v0.3.0
 	github.com/sirupsen/logrus v1.5.0
 	gopkg.in/square/go-jose.v2 v2.4.1
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4er
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,6 +1,13 @@
 package internal
 
 type Config struct {
-	Address string `yaml:"address"`
-	Port    int    `yaml:"port"`
+	Address string   `yaml:"address"`
+	Port    int      `yaml:"port"`
+	Issuers []Issuer `yaml:"issuers"`
+}
+
+type Issuer struct {
+	Name      string      `yaml:"name"`
+	Issuer    string      `yaml:"issuer"`
+	PublicKey interface{} `yaml:"publicKey"`
 }

--- a/internal/server.go
+++ b/internal/server.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Handler(w http.ResponseWriter, r *http.Request) {
+func (c *Config) Handler(w http.ResponseWriter, r *http.Request) {
 	response := auth.TokenReview{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: auth.SchemeGroupVersion.String(),
@@ -18,7 +18,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	if identity, err := fromRequest(r); err != nil {
+	if identity, err := c.fromRequest(r); err != nil {
 		log.Info(err)
 		response.Status = auth.TokenReviewStatus{
 			Authenticated: false,
@@ -39,7 +39,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 
-func fromRequest(r *http.Request) (Identity, error) {
+func (c *Config) fromRequest(r *http.Request) (Identity, error) {
 	decoder := json.NewDecoder(r.Body)
 
 	var tokenReview auth.TokenReview
@@ -47,7 +47,7 @@ func fromRequest(r *http.Request) (Identity, error) {
 		return Identity{}, fmt.Errorf("decode request body: %v", err)
 	}
 
-	identity, err := validate(tokenReview.Spec.Token)
+	identity, err := c.validate(tokenReview.Spec.Token)
 	if err != nil {
 		return Identity{}, err
 	}

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -1,0 +1,89 @@
+package internal
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+type Claims struct {
+	*jwt.Claims
+	Username string   `json:"username"`
+	Groups   []string `json:"groups"`
+}
+
+func TestValidate(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Errorf("%v", err)
+		return
+	}
+
+	signingKey := jose.SigningKey{
+		Algorithm: jose.RS256,
+		Key:       key,
+	}
+
+	options := jose.SignerOptions{}
+	options.WithType("JWT")
+
+	signer, err := jose.NewSigner(signingKey, &options)
+	if err != nil {
+		t.Errorf("%v", err)
+		return
+	}
+
+	claims := Claims{
+		Claims: &jwt.Claims{
+			Issuer:   "issuer",
+			Audience: []string{"audience"},
+			Subject:  "subject",
+			IssuedAt: jwt.NewNumericDate(time.Now()),
+			Expiry:   jwt.NewNumericDate(time.Now().Add(300 * time.Second)),
+		},
+		Username: "username",
+		Groups:   []string{"group1", "group2"},
+	}
+
+	builder := jwt.Signed(signer)
+
+	token, err := builder.Claims(claims).CompactSerialize()
+	if err != nil {
+		t.Errorf("%v", err)
+		return
+	}
+
+	issuer := Issuer{
+		Name:      "name",
+		Issuer:    "issuer",
+		PublicKey: key.Public(),
+	}
+
+	config := Config{
+		Address: "0.0.0.0",
+		Port:    443,
+		Issuers: []Issuer{issuer},
+	}
+
+	identity, err := config.validate(token)
+	if err != nil {
+		t.Errorf("%v", err)
+		return
+	}
+
+	expected := Identity{
+		UID:      "subject",
+		Username: "username",
+		Groups:   []string{"group1", "group2"},
+	}
+
+	if !cmp.Equal(identity, expected) {
+		t.Errorf("token identity did not match expected value:\n%s", cmp.Diff(expected, identity))
+		return
+	}
+}

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	http.HandleFunc("/", internal.Handler)
+	http.HandleFunc("/", config.Handler)
 	bind := fmt.Sprintf("%s:%d", config.Address, config.Port)
 	log.Fatal(http.ListenAndServe(bind, nil))
 }


### PR DESCRIPTION
Adds an `issuers` field to the config file. Finds all issuers matching the `iss` field in the JWT and attempts to find one with a public key which can be used to verify the signature.