### PR TITLE
Generate identity from template

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -1,5 +1,10 @@
 package internal
 
+import (
+	"fmt"
+	"text/template"
+)
+
 type Config struct {
 	Address string   `yaml:"address"`
 	Port    int      `yaml:"port"`
@@ -7,7 +12,52 @@ type Config struct {
 }
 
 type Issuer struct {
-	Name      string      `yaml:"name"`
-	Issuer    string      `yaml:"issuer"`
-	PublicKey interface{} `yaml:"publicKey"`
+	Name      string           `yaml:"name"`
+	Issuer    string           `yaml:"issuer"`
+	PublicKey interface{}      `yaml:"publicKey"`
+	Template  IdentityTemplate `yaml:"template"`
+}
+
+type IdentityTemplate struct {
+	UID         *template.Template
+	Username    *template.Template
+	Group       *template.Template
+	GroupsField string
+}
+
+func (x *IdentityTemplate) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var wrapper struct {
+		UID         string `yaml:"uid"`
+		Username    string `yaml:"username"`
+		Group       string `yaml:"group"`
+		GroupsField string `yaml:"groupsField"`
+	}
+
+	if err := unmarshal(&wrapper); err != nil {
+		return fmt.Errorf("unmarshal IdentityTemplate: %v", err)
+	}
+
+	uid, err := template.New("UID").Option("missingkey=error").Parse(wrapper.UID)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	username, err := template.New("username").Option("missingkey=error").Parse(wrapper.Username)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	group, err := template.New("group").Option("missingkey=error").Parse(wrapper.Group)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	*x = IdentityTemplate{
+		UID:         uid,
+		Username:    username,
+		Group:       group,
+		GroupsField: wrapper.GroupsField,
+	}
+
+	return nil
 }

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -58,10 +59,18 @@ func TestValidate(t *testing.T) {
 		return
 	}
 
+	tpl := IdentityTemplate{
+		UID:         createTemplate("UID", "{{ .sub }}"),
+		Username:    createTemplate("Username", "{{ .username }}"),
+		Group:       createTemplate("Group", "{{ . }}"),
+		GroupsField: "groups",
+	}
+
 	issuer := Issuer{
 		Name:      "name",
 		Issuer:    "issuer",
 		PublicKey: key.Public(),
+		Template:  tpl,
 	}
 
 	config := Config{
@@ -86,4 +95,8 @@ func TestValidate(t *testing.T) {
 		t.Errorf("token identity did not match expected value:\n%s", cmp.Diff(expected, identity))
 		return
 	}
+}
+
+func createTemplate(name string, t string) *template.Template {
+	return template.Must(template.New(name).Option("missingkey=error").Parse(t))
 }


### PR DESCRIPTION
Allows the configuration file to be used to specify templates for all of the `Identity` fields. Templates have access to the claims from the JWT.