### PR TITLE
Parse PEM encoded public key

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
@@ -28,8 +29,14 @@ func (c *Config) validate(tokenString string) (Identity, error) {
 	found := Issuer{}
 	for _, i := range c.Issuers {
 		if i.Issuer == publicClaims.Issuer {
+			publicKey, err := i.GetPublicKey()
+			if err != nil {
+				log.Warnf("get public key for issuer %q: %v", i.Name, err)
+				continue
+			}
+
 			var ignore jwt.Claims
-			if err := token.Claims(i.PublicKey, &ignore); err == nil {
+			if err := token.Claims(publicKey, &ignore); err == nil {
 				found = i
 				break
 			}

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -67,10 +67,11 @@ func TestValidate(t *testing.T) {
 	}
 
 	issuer := Issuer{
-		Name:      "name",
-		Issuer:    "issuer",
-		PublicKey: key.Public(),
-		Template:  tpl,
+		Name:          "name",
+		Issuer:        "issuer",
+		PublicKey:     "filepath",
+		Template:      tpl,
+		PublicKeyData: key.Public(),
 	}
 
 	config := Config{

--- a/main.go
+++ b/main.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
 	"github.com/robbiemcmichael/kube-auth-hub/internal"


### PR DESCRIPTION
Parse PEM encoded public keys to use when validating the JWT received in the token review request.